### PR TITLE
feat: Implement Dark Mode and Arabic Localization Structure

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,4 @@
+arb-dir: lib/l10n
+template-arb-file: intl_en.arb
+output-localization-file: app_localizations.dart
+use-deferred-loading: false

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -1,0 +1,8 @@
+{
+  "@@locale": "ar",
+  "settingsPageTitle": "الإعدادات",
+  "darkModeLabel": "الوضع الداكن",
+  "languageLabel": "اللغة",
+  "englishLanguage": "الإنجليزية (English)",
+  "arabicLanguage": "العربية"
+}

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,0 +1,8 @@
+{
+  "@@locale": "en",
+  "settingsPageTitle": "Settings",
+  "darkModeLabel": "Dark Mode",
+  "languageLabel": "Language",
+  "englishLanguage": "English",
+  "arabicLanguage": "Arabic (العربية)"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,22 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:learny/pages/splash.dart'; // Your custom splash screen
-import 'package:shared_preferences/shared_preferences.dart'; // Import SharedPreferences
+import 'package:learny/services/theme_service.dart';
+import 'package:learny/services/locale_service.dart'; // Added
+import 'package:provider/provider.dart';
+import 'package:flutter_localizations/flutter_localizations.dart'; // Added
+
+// TODO: After running 'flutter gen-l10n', import the generated file:
+// import 'package:learny/.dart_tool/flutter_gen/gen_l10n/app_localizations.dart';
+// For now, we'll use placeholder delegates and locales.
+
 
 Future<void> main() async { // Make main async
   WidgetsFlutterBinding.ensureInitialized(); // Ensures bindings are ready
 
-  // Attempt to initialize SharedPreferences here.
-  // This makes it more likely to be ready when SplashScreen needs it.
-  try {
-    await SharedPreferences.getInstance();
-    print("SharedPreferences initialized successfully in main.");
-  } catch (e) {
-    print("Error initializing SharedPreferences in main: $e");
-    // In a real app, you might want to handle this critical failure,
-    // perhaps by showing a static error screen instead of runApp.
-  }
+  final themeService = await ThemeService.create();
+  final localeService = await LocaleService.create(); // Added
 
-  runApp(const MyApp());
+  runApp(
+    MultiProvider( // Changed to MultiProvider
+      providers: [
+        ChangeNotifierProvider<ThemeService>(create: (_) => themeService),
+        ChangeNotifierProvider<LocaleService>(create: (_) => localeService), // Added
+      ],
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
@@ -24,12 +32,44 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final themeService = Provider.of<ThemeService>(context);
+    final localeService = Provider.of<LocaleService>(context); // Added
+
+    final ThemeData lightTheme = ThemeData(
+      primarySwatch: Colors.purple,
+      fontFamily: 'Afacad',
+      brightness: Brightness.light,
+    );
+
+    final ThemeData darkTheme = ThemeData.dark().copyWith(
+      primarySwatch: Colors.purple,
+      fontFamily: 'Afacad',
+      brightness: Brightness.dark,
+      // Example: customize accent color for dark theme
+      // accentColor: Colors.purpleAccent, // This property is deprecated, use colorScheme.secondary instead
+      colorScheme: ColorScheme.dark(
+        primary: Colors.purple,
+        secondary: Colors.purpleAccent, // This is an example, adjust as needed
+      ),
+    );
+
     return MaterialApp(
       title: 'EduBoost',
-      theme: ThemeData(
-        primarySwatch: Colors.purple,
-        fontFamily: 'Afacad',
-      ),
+      theme: lightTheme,
+      darkTheme: darkTheme,
+      themeMode: themeService.isDarkMode ? ThemeMode.dark : ThemeMode.light,
+      locale: localeService.locale, // Added
+      // TODO: Replace with AppLocalizations.localizationsDelegates after 'flutter gen-l10n'
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      // TODO: Replace with AppLocalizations.supportedLocales after 'flutter gen-l10n'
+      supportedLocales: const [
+        Locale('en', ''), // English, no country code
+        Locale('ar', ''), // Arabic, no country code
+      ],
       debugShowCheckedModeBanner: false,
       home: const SplashScreen(), // SplashScreen handles navigation after its animation
     );

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,68 +1,66 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:learny/services/theme_service.dart';
+import 'package:learny/services/locale_service.dart'; // Added
 
-class SettingsPage extends StatefulWidget {
+// TODO: After running 'flutter gen-l10n', import the generated file:
+// import 'package:learny/.dart_tool/flutter_gen/gen_l10n/app_localizations.dart';
+
+class SettingsPage extends StatelessWidget {
   const SettingsPage({super.key});
 
   @override
-  State<SettingsPage> createState() => _SettingsPageState();
-}
-
-class _SettingsPageState extends State<SettingsPage> {
-  bool _isDarkMode = false;
-  String _selectedLanguage = 'English'; // Default language
-
-  @override
   Widget build(BuildContext context) {
+    final themeService = Provider.of<ThemeService>(context);
+    final localeService = Provider.of<LocaleService>(context); // Added
+    // final appLocalizations = AppLocalizations.of(context)!; // TODO: Uncomment after 'flutter gen-l10n'
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Settings', style: TextStyle(fontFamily: 'Afacad', color: Colors.white)),
+        // TODO: Replace with appLocalizations.settingsPageTitle
+        title: Text(localeService.locale.languageCode == 'ar' ? 'الإعدادات' : 'Settings', style: const TextStyle(fontFamily: 'Afacad', color: Colors.white)),
         backgroundColor: const Color(0xFFBF33FF), // Your app's primary color
         iconTheme: const IconThemeData(color: Colors.white),
       ),
-      backgroundColor: Colors.white,
       body: ListView(
         padding: const EdgeInsets.all(16.0),
         children: [
           SwitchListTile(
-            title: const Text('Dark Mode', style: TextStyle(fontFamily: 'Afacad', fontSize: 18)),
-            secondary: Icon(_isDarkMode ? Icons.dark_mode_outlined : Icons.light_mode_outlined),
-            value: _isDarkMode,
+            // TODO: Replace with appLocalizations.darkModeLabel
+            title: Text(localeService.locale.languageCode == 'ar' ? 'الوضع الداكن' : 'Dark Mode', style: const TextStyle(fontFamily: 'Afacad', fontSize: 18)),
+            secondary: Icon(themeService.isDarkMode ? Icons.dark_mode_outlined : Icons.light_mode_outlined),
+            value: themeService.isDarkMode,
             onChanged: (bool value) {
-              setState(() {
-                _isDarkMode = value;
-                // TODO: Implement actual dark mode theme switching logic
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('Dark Mode ${value ? "Enabled" : "Disabled"} (UI not implemented)')),
-                );
-              });
+              themeService.toggleTheme();
             },
           ),
           const Divider(),
           ListTile(
-            title: const Text('Language', style: TextStyle(fontFamily: 'Afacad', fontSize: 18)),
-            trailing: DropdownButton<String>(
-              value: _selectedLanguage,
+            // TODO: Replace with appLocalizations.languageLabel
+            title: Text(localeService.locale.languageCode == 'ar' ? 'اللغة' : 'Language', style: const TextStyle(fontFamily: 'Afacad', fontSize: 18)),
+            trailing: DropdownButton<Locale>( // Changed to DropdownButton<Locale>
+              value: localeService.locale, // Use locale from LocaleService
               icon: const Icon(Icons.arrow_drop_down),
               elevation: 16,
-              style: const TextStyle(color: Color(0xFFBF33FF), fontFamily: 'Afacad', fontSize: 16),
+              style: TextStyle(color: Theme.of(context).colorScheme.secondary, fontFamily: 'Afacad', fontSize: 16),
               underline: Container(
                 height: 2,
-                color: const Color(0xFFBF33FF),
+                color: Theme.of(context).colorScheme.secondary,
               ),
-              onChanged: (String? newValue) {
-                setState(() {
-                  _selectedLanguage = newValue!;
-                  // TODO: Implement actual language switching logic (e.g., using localization packages)
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('Language changed to $newValue (Localization not implemented)')),
-                  );
-                });
+              onChanged: (Locale? newValue) {
+                if (newValue != null) {
+                  localeService.setLocale(newValue);
+                }
               },
-              items: <String>['English', 'العربية (Arabic)']
-                  .map<DropdownMenuItem<String>>((String value) {
-                return DropdownMenuItem<String>(
-                  value: value,
-                  child: Text(value),
+              // TODO: Update to use AppLocalizations.supportedLocales and display names from actual localizations after 'flutter gen-l10n'
+              items: [
+                const Locale('en', ''),
+                const Locale('ar', '')
+              ].map<DropdownMenuItem<Locale>>((Locale locale) {
+                return DropdownMenuItem<Locale>(
+                  value: locale,
+                  // TODO: Replace with appLocalizations.englishLanguage / appLocalizations.arabicLanguage or a more robust solution
+                  child: Text(locale.languageCode == 'ar' ? 'العربية (Arabic)' : 'English'),
                 );
               }).toList(),
             ),

--- a/lib/services/locale_service.dart
+++ b/lib/services/locale_service.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LocaleService extends ChangeNotifier {
+  static const _localeKey = 'locale_code';
+  late SharedPreferences _prefs;
+  Locale _locale = const Locale('en'); // Default to English
+
+  LocaleService._privateConstructor(); // Private constructor
+
+  static Future<LocaleService> create() async {
+    final service = LocaleService._privateConstructor();
+    await service._init();
+    return service;
+  }
+
+  Future<void> _init() async {
+    _prefs = await SharedPreferences.getInstance();
+    final languageCode = _prefs.getString(_localeKey);
+    if (languageCode != null) {
+      _locale = Locale(languageCode);
+    }
+  }
+
+  Locale get locale => _locale;
+
+  void setLocale(Locale newLocale) {
+    if (_locale == newLocale) return; // No change
+
+    _locale = newLocale;
+    _prefs.setString(_localeKey, newLocale.languageCode);
+    notifyListeners();
+  }
+}

--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeService extends ChangeNotifier {
+  static const _themeModeKey = 'themeMode';
+  late SharedPreferences _prefs;
+  bool _isDarkMode = false;
+
+  ThemeService._privateConstructor(); // Private constructor
+
+  static Future<ThemeService> create() async {
+    final service = ThemeService._privateConstructor();
+    await service._init();
+    return service;
+  }
+
+  Future<void> _init() async {
+    _prefs = await SharedPreferences.getInstance();
+    _isDarkMode = _prefs.getBool(_themeModeKey) ?? false;
+  }
+
+  bool get isDarkMode => _isDarkMode;
+
+  void toggleTheme() {
+    _isDarkMode = !_isDarkMode;
+    _prefs.setBool(_themeModeKey, _isDarkMode);
+    notifyListeners();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations: # Added
+    sdk: flutter        # Added
 
+  intl: ^0.19.0 # Added
   cupertino_icons: ^1.0.8
   google_fonts: ^6.2.1
   image_picker: ^1.1.2
   shared_preferences: ^2.5.3
+  provider: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I've added Dark Mode functionality and set up the structure for Arabic localization.

Features:
- Dark Mode:
  - You can toggle Dark Mode from the Settings page.
  - Your theme preference is saved and persists across app sessions.
  - I implemented this using Provider for state management and SharedPreferences for persistence.

- Arabic Localization:
  - I've put in place the basic structure for Arabic and English localization.
  - You can select English or Arabic from the Settings page.
  - Your language preference is saved and persists across app sessions.
  - I implemented this using Provider for state management, SharedPreferences for persistence, and the intl package for localization.

**IMPORTANT MANUAL STEPS REQUIRED:**

To complete the localization setup, please perform the following steps in your local Flutter environment:

1.  **Install Dependencies:** Run `flutter pub get` in your terminal at the project root. This will download the necessary packages (`flutter_localizations`, `intl`, `provider`).

2.  **Generate Localization Files:** Run `flutter gen-l10n` in your terminal at the project root. This will generate the required `app_localizations.dart` file and other related localization files based on the `.arb` files in `lib/l10n/`.

3.  **Update Code with Generated Localizations:** After the files are generated, you will need to update a few spots in the code:

    *   **`lib/main.dart`:**
        *   Uncomment or add the import for the generated `app_localizations.dart` file (e.g., `import 'package:learny/.dart_tool/flutter_gen/gen_l10n/app_localizations.dart';` - the exact path might be slightly different depending on your project name).
        *   Replace the placeholder `localizationsDelegates` with `AppLocalizations.localizationsDelegates`.
        *   Replace the placeholder `supportedLocales` with `AppLocalizations.supportedLocales`.

    *   **`lib/pages/settings_page.dart`:**
        *   Uncomment or add the import for the generated `app_localizations.dart`.
        *   Replace the hardcoded strings for the AppBar title, "Dark Mode" label, and "Language" label with calls to `AppLocalizations.of(context)!.yourStringKey` (e.g., `appLocalizations.settingsPageTitle`, `appLocalizations.darkModeLabel`, `appLocalizations.languageLabel`).
        *   Update the `DropdownButton` items to dynamically create items from `AppLocalizations.supportedLocales` and display appropriate language names using the generated localizations if desired.

After these manual steps, the localization for Arabic should be fully functional, and the text on the Settings page will update according to the selected language.